### PR TITLE
More efficient `FreeGroupL` operations

### DIFF
--- a/src/Data/Group/Free.hs
+++ b/src/Data/Group/Free.hs
@@ -8,7 +8,6 @@
  -}
 module Data.Group.Free
     ( FreeGroup
-    , cons
     , fromDList
     , toDList
     , normalize
@@ -80,29 +79,6 @@ normalize = DList.foldr fn DList.empty
                 (Left x,  Right y) | x == y -> bs
                 (Right x, Left y)  | x == y -> bs
                 _                           -> DList.cons a as
-
--- | Cons a generator (@'Right' x@) or its inverse (@'Left' x@) to the left
--- hand side of a 'FreeGroupL'.
---
--- Complexity: @O(n)@
-cons
-    :: Eq a
-    => Either a a
-    -> FreeGroup a
-    -> FreeGroup a
-cons a (FreeGroup as) = FreeGroup (cons_ a as)
-
-cons_
-    :: Eq a
-    => Either a a
-    -> DList (Either a a)
-    -> DList (Either a a)
-cons_ a = DList.list (DList.singleton a) $ \b bs ->
-    case (a, b) of
-      (Left x,  Right y) | x == y -> bs
-      (Right x, Left y)  | x == y -> bs
-      _                           -> a `DList.cons` b `DList.cons` bs
-
 
 -- |
 -- Smart constructor which normalizes a list.

--- a/src/Data/Group/Free.hs
+++ b/src/Data/Group/Free.hs
@@ -123,7 +123,13 @@ normalizeL
     :: Eq a
     => [Either a a]
     -> [Either a a]
-normalizeL = DList.toList . normalize . DList.fromList
+normalizeL = foldr fn []
+    where
+    fn a []     = [a]
+    fn a as@(b:bs) = case (a, b) of
+      (Left x,  Right y) | x == y -> bs
+      (Right x, Left y)  | x == y -> bs
+      _                           -> a : as
 
 -- |
 -- Smart constructors


### PR DESCRIPTION
Hi;

Thank you for the great library!  It's been a real treat to use :)

Just a simple PR that changes the implementation of `<>` and `normalize` for `FreeGroupL`.  Previously they were implemented in terms of `FreeGroup`'s `<>` and `normalize`, but looking at the internal code, `normalize` seems to be `O(n^2)`, and not `O(n)` as might have been suspected.  That's because tail and heads are O(n), and foldr is also O(n), so if we do a tail/heads on every item in the list, we get O(n^2).

I've re-implemented `normalize` directly for `FreeGroupL` to be `O(n)`, using the `O(1)` `head` and `tail` for `[]`.  I've also adjusted `<>` the same way.

In the end there was a useful operator, `consL`, which arose out of the internal code:

```haskell
-- O(1)
consL :: Either a a -> FreeGrouL a -> FreeGroupL a
```

which I think would be a useful general combinator.  I considered adding the same `cons` for `FreeGroup`, but I feel like it might not make sense as an operation, because `FreeGroup` is meant to have no preferred direction of expansion.

Let me know if there's anything I should modify, or if this isn't what you are looking for at this time :)