### PR TITLE
Build with GHC 9.8 and 9.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2"]
+        ghc: ["8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2", "9.8.2", "9.10.1"]
         os: [ubuntu-latest]
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
-index-state:    2023-06-04T00:00:00Z
+index-state:    2024-07-17T08:43:29Z
+
 packages:       .
                 examples

--- a/free-algebras.cabal
+++ b/free-algebras.cabal
@@ -19,7 +19,7 @@ extra-source-files:
     ChangeLog.md
     README.md
 stability:      experimental
-tested-with:    GHC == { 8.10, 9.0, 9.2, 9.4, 9.6 }
+tested-with:    GHC == { 8.10, 9.0, 9.2, 9.4, 9.6, 9.8, 9.10 }
 
 source-repository head
   type: git

--- a/free-algebras.cabal
+++ b/free-algebras.cabal
@@ -92,7 +92,7 @@ test-suite test-free-algebras
     , dlist
     , free
     , groups
-    , hedgehog       >= 0.6 && < 1.3
+    , hedgehog       >= 0.6 && < 1.5
     , kan-extensions
     , mtl
     , transformers


### PR DESCRIPTION
I built successfully with 9.8, I believe it should support GHC 9.10 out of the box.