### PR TITLE
free-algebras-0.1.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,16 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2", "9.8.2", "9.10.1"]
+        ghc: ["8.10", "9.0", "9.2", "9.4", "9.6", "9.8", "9.10"]
         os: [ubuntu-latest]
 
     steps:
     - name: Install Haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.8.1.0
+        cabal-version: 3.12.1.0
 
     - name: Select build directory
       run: |
@@ -48,7 +48,7 @@ jobs:
         echo "TMPDIR=$RUNNER_TEMP"  >> $GITHUB_ENV
         echo "TMP=$RUNNER_TEMP"     >> $GITHUB_ENV
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Record dependencies
       id: record-deps
@@ -57,14 +57,14 @@ jobs:
         cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
 
     - name: Cache `cabal store`
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
         key: cabal-store-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
         restore-keys: cabal-store-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
     - name: Cache `dist-newstyle`
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           dist-newstyle

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for free-algebras
 
+## Version 0.1.2.0
+
+- Support `GHC-9.10`.
+
 ## Version 0.1.1.0
 - Support `GHC-9.6` and `mtl-2.3`, drop support of `GHC-8.8`.
 

--- a/examples/src/Data/Algebra/Free/Monadicity.hs
+++ b/examples/src/Data/Algebra/Free/Monadicity.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE GADTs                 #-}
@@ -51,6 +52,11 @@ import           Prelude
 import           Data.Bifunctor (bimap)
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
+#if __GLASGOW_HASKELL__ >= 910
+import qualified Data.Functor as X (unzip)
+#else
+import qualified Data.List.NonEmpty as X (unzip)
+#endif
 import           Data.Proxy (Proxy (..))
 import           Data.Kind (Type)
 
@@ -265,7 +271,7 @@ instance {-# OVERLAPPING #-} MAlg NonEmpty (NonEmpty a) where
 -- |
 -- Wrapping an @MAlg@ inside a monad is a 
 instance {-# OVERLAPPABLE #-} (Functor m, MAlg m a, MAlg m b) => MAlg m (a, b) where
-    alg = bimap alg alg . NE.unzip
+    alg = bimap alg alg . X.unzip
 
 -- |
 -- TODO: is this a lawful instance?

--- a/free-algebras.cabal
+++ b/free-algebras.cabal
@@ -51,7 +51,7 @@ library
       src
   build-depends:
       base            >= 4.9 && <5
-    , containers      >= 0.4.2 && <0.7
+    , containers      >= 0.4.2 && <0.8
     , data-fix                  <0.4
     , dlist           >= 0.8 && <1.1
     , free            >= 4.0 && <6.0
@@ -92,7 +92,7 @@ test-suite test-free-algebras
     , dlist
     , free
     , groups
-    , hedgehog       >= 0.6 && < 1.5
+    , hedgehog       >= 0.6 && < 1.6
     , kan-extensions
     , mtl
     , transformers

--- a/free-algebras.cabal
+++ b/free-algebras.cabal
@@ -1,6 +1,6 @@
-cabal-version:  3.0
+cabal-version:  3.4
 name:           free-algebras
-version:        0.1.1.1
+version:        0.1.2.0
 synopsis:       Free algebras
 description:
   Algebraic approach to free algebras, inspired by Univeral Algebra and
@@ -11,7 +11,7 @@ homepage:       https://github.com/coot/free-algebras#readme
 bug-reports:    https://github.com/coot/free-algebras/issues
 author:         Marcin Szamotulski
 maintainer:     coot@coot.me
-copyright:      (c) 2018-2022 Marcin Szamotulski
+copyright:      (c) 2018-2024 Marcin Szamotulski
 license:        MPL-2.0
 license-file:   LICENSE
 build-type:     Simple

--- a/src/Control/Algebra/Free.hs
+++ b/src/Control/Algebra/Free.hs
@@ -18,6 +18,7 @@
 
 -- 'ListT' transformer is depreciated
 {-# OPTIONS_GHC -Wno-deprecations       #-}
+{-# OPTIONS_GHC -Wno-orphans            #-}
 
 module Control.Algebra.Free
     ( -- Higher free algebra class

--- a/src/Data/Group/Free.hs
+++ b/src/Data/Group/Free.hs
@@ -29,7 +29,9 @@ import qualified Data.DList as DList
 import           Data.DList.Unsafe (DList (..))
 #endif
 import           Data.Group (Group (..))
+#if __GLASGOW_HASKELL__ < 910
 import           Data.List (foldl')
+#endif
 
 import           Data.Algebra.Free
                     ( AlgebraType


### PR DESCRIPTION
- **Updated GHA workflow**
- **Fix / suppress ghc-9.10 warnings**
- **Updated dependencies**
- **Bump version: 0.1.2.0**
